### PR TITLE
Update typewriter presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ We provide a collection of presets to animate your components easily:
 - **Shake**: `motion-preset-shake`
 - **Wiggle**: `motion-preset-wiggle`
 - **Confetti**: `motion-preset-confetti`
-- **Typewriter**: `motion-preset-typewriter-[number of characters]`
+- **Typewriter**: 
+  - Infinite: `motion-preset-typewriter-infinite-[number of characters]`
+  - Animate Once: `motion-preset-typewriter-[number of characters]`
 - **Flomoji**: `motion-preset-flomoji`
 
 ### Customizing Presets

--- a/src/presets.js
+++ b/src/presets.js
@@ -512,7 +512,7 @@ export function addPresets(addComponents, matchComponents, theme) {
   });
 
   matchComponents({
-    "motion-preset-typewriter": (value) => ({
+    "motion-preset-typewriter-infinite": (value) => ({
       "--motion-duration": "2000ms",
       "--motion-typewriter-value": `${value}ch`,
       animation: `typing var(--motion-duration) steps(${value}) infinite, blink 0.4s step-end infinite alternate`,
@@ -534,6 +534,36 @@ export function addPresets(addComponents, matchComponents, theme) {
 
       "@keyframes blink": {
         "50%": {
+          borderColor: "transparent",
+        },
+      },
+    }),
+
+    "motion-preset-typewriter": (value) => ({
+      "--motion-duration": "600ms",
+      "--motion-typewriter-value": `${value}ch`,
+      animation: `typingOnce var(--motion-duration) steps(${value}) forwards, blinkOnce calc(var(--motion-duration) + 0.4s) forwards`,
+      whiteSpace: "nowrap",
+      borderRight: "2px solid",
+      fontFamily: "monospace",
+      overflow: "hidden",
+
+      "@media screen and (prefers-reduced-motion: no-preference)": {
+        "@keyframes typingOnce": {
+          "0%": {
+            width: "0",
+          },
+          "to": {
+            width: `calc(var(--motion-typewriter-value) + 1px)`,
+          },
+        },
+      },
+
+      "@keyframes blinkOnce": {
+        "0%, 99%": {
+          borderColor: "currentColor",
+        },
+        "100%": {
           borderColor: "transparent",
         },
       },


### PR DESCRIPTION
This **PR** proposes to:

- Make the current `motion-preset-typewriter` animate only once by default.
- Create a new infinite preset which will work similar to the current `motion-preset-typewriter`, i.e. animate infinitely.

To test:

1. Add these divs to [index.astro](https://github.com/romboHQ/tailwindcss-motion/blob/main/web/src/pages/index.astro)
2. Start the **Astro** project

```
<!-- Test infinite animation -->
<div class="motion-preset-typewriter-infinite-[23]">This will type forever.</div>

<!-- Test one-time animation -->
<div class="motion-preset-typewriter-[20]">This will type once.</div>
```

> Also addresses Issue #6 