### PR TITLE
add looping animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ✨ [tailwindcss-motion β](https://rombo.co/tailwind/) ✨ 
+# ✨ [tailwindcss-motion β](https://rombo.co/tailwind/) ✨
 
 [![NPM Version](https://img.shields.io/npm/v/tailwindcss-motion?color=F3FC6F)](https://www.npmjs.com/package/tailwindcss-motion)
 [![NPM Downloads](https://img.shields.io/npm/dw/tailwindcss-motion?color=F3FC6F)](https://www.npmjs.com/package/tailwindcss-motion)
@@ -55,6 +55,8 @@ For example, for a slide and fade effect — you simply need `motion-translate-x
 
 We provide a collection of presets to animate your components easily:
 
+### Enter Animation Presets
+
 - **Fade**: `motion-preset-fade`
 - **Slide**:
   - Right: `motion-preset-slide-right`
@@ -77,6 +79,17 @@ We provide a collection of presets to animate your components easily:
 - **Confetti**: `motion-preset-confetti`
 - **Typewriter**: `motion-preset-typewriter-[number of characters]`
 - **Flomoji**: `motion-preset-flomoji`
+
+### Loop Animation Presets
+
+- **Pulse**: `motion-preset-pulse`
+- **Wobble**: `motion-preset-wobble`
+- **Seesaw**: `motion-preset-seesaw`
+- **Oscillate**: `motion-preset-oscillate`
+- **Stretch**: `motion-preset-stretch`
+- **Float**: `motion-preset-float`
+- **Spin**: `motion-preset-spin`
+- **Blink**: `motion-preset-blink`
 
 ### Customizing Presets
 
@@ -133,13 +146,75 @@ You can combine multiple animations on a single element:
 
 For exit animations, simply replace `in` with `out` in the class name.
 
+## Loop Animations
+
+You can create continuous animations by adding loop variants to any base animation class. Simply replace `in` with `loop` in the class name.
+
+### Basic Loop Usage
+
+```html
+<div class="motion-translate-y-loop-25"></div>
+```
+
+### Loop Modifiers
+
+Loops support two animation styles controlled by modifiers:
+
+- `mirror` (default): Animation reverses direction when reaching the end
+- `reset`: Animation resets to starting position when reaching the end
+
+```html
+<!-- Mirror animation (default) -->
+<div class="motion-translate-y-loop-25/mirror"></div>
+
+<!-- Reset animation -->
+<div class="motion-translate-y-loop-25/reset"></div>
+```
+
+### Loop Count
+
+Control how many times the animation repeats using the `motion-loop` utility:
+
+- `motion-loop-once`: Animation repeats once
+- `motion-loop-twice`: Animation repeats twice
+- `motion-loop-infinite`: Animation repeats indefinitely (default)
+
+```html
+<!-- Infinite loop (default) -->
+<div class="motion-translate-y-loop-25"></div>
+
+<!-- Loop twice -->
+<div class="motion-translate-y-loop-25 motion-loop-twice"></div>
+
+<!-- Loop once -->
+<div class="motion-translate-y-loop-25 motion-loop-once"></div>
+```
+
+You can also target specific properties:
+
+```html
+<!-- Only loop the translation twice -->
+<div class="motion-translate-y-loop-25 motion-loop-twice/translate"></div>
+```
+
+### Combining Loop Animations
+
+Multiple loop animations can be combined:
+
+```html
+<div
+  class="motion-scale-loop-75 motion-translate-y-loop-25 motion-rotate-loop-180"
+></div>
+```
+
 ## Modifiers
 
-You can customize the duration, delay, and timing function of any animation.
+You can customize the duration, delay, timing function, and play state of any animation.
 
 - **Duration**: `motion-duration-500`
 - **Delay**: `motion-delay-500`
 - **Timing Function**: `motion-timing-spring-bouncy`
+- **Play State**: `motion-paused` or `motion-running`
 
 For example:
 
@@ -150,6 +225,18 @@ For example:
 ```
 
 This applies a duration of 2000ms to both the rotation and opacity animations.
+
+### Animation Play State
+
+You can pause and resume animations using the play state utilities:
+
+```html
+<!-- Pause the animation -->
+<div class="motion-preset-bounce motion-paused"></div>
+
+<!-- Resume the animation -->
+<div class="motion-preset-bounce motion-running"></div>
+```
 
 ### Modifiers for each property
 
@@ -198,5 +285,12 @@ Apple Color Swatches - https://play.tailwindcss.com/cvQ3Nk3v8j
 ![example-4](https://github.com/user-attachments/assets/887fba04-9642-4a4f-8ace-7375a4aa65b6)
 
 ## What's Rombo?
+
 Rombo is an early-stage company, building tools to help companies build beautiful interactive interfaces. We're starting out with a toolkit for engineers, designers and creative marketers to animate natively inside common Workflows — like Tailwind, Figma, Webflow, Shopify & more to come!
-Sign up for updates on our site at https://rombo.co
+Sign up for our waitlist at https://rombo.co/tailwind/#waitlist
+
+## More Resources
+
+- [Bringing Motion to Tailwind CSS: Building an animation plugin at Rombo](https://www.kvin.me/posts/tailwind-motion) - Blog post about the creation of this library
+- [Animator Builder](https://rombo.co/tailwind/#animator) - Create animations intuitively and export them to Tailwind classes
+- [UnoCSS port](https://github.com/whatnickcodes/unocss-preset-tailwindcss-motion) - Port created by [@whatnickcodes](https://github.com/whatnickcodes)

--- a/src/baseAnimations.js
+++ b/src/baseAnimations.js
@@ -5,30 +5,50 @@ export const scaleInAnimation =
   "motion-scale-in calc(var(--motion-scale-duration) * var(--motion-scale-perceptual-duration-multiplier)) var(--motion-scale-timing) var(--motion-scale-delay) both";
 export const scaleOutAnimation =
   "motion-scale-out calc(var(--motion-scale-duration) * var(--motion-scale-perceptual-duration-multiplier)) var(--motion-scale-timing) var(--motion-scale-delay) both";
+export const scaleLoopAnimation = (type) =>
+  `motion-scale-loop-${type} calc(var(--motion-scale-duration) * var(--motion-scale-perceptual-duration-multiplier)) var(--motion-scale-timing) var(--motion-scale-delay) both var(--motion-scale-loop-count)`;
+
 export const translateInAnimation =
   "motion-translate-in calc(var(--motion-translate-duration) * var(--motion-translate-perceptual-duration-multiplier)) var(--motion-translate-timing) var(--motion-translate-delay) both";
 export const translateOutAnimation =
   "motion-translate-out calc(var(--motion-translate-duration) * var(--motion-translate-perceptual-duration-multiplier)) var(--motion-translate-timing) var(--motion-translate-delay) both";
+export const translateLoopAnimation = (type) =>
+  `motion-translate-loop-${type} calc(var(--motion-translate-duration) * var(--motion-translate-perceptual-duration-multiplier)) var(--motion-translate-timing) var(--motion-translate-delay) both var(--motion-translate-loop-count)`;
+
 export const rotateInAnimation =
   "motion-rotate-in calc(var(--motion-rotate-duration) * var(--motion-rotate-perceptual-duration-multiplier)) var(--motion-rotate-timing) var(--motion-rotate-delay) both";
 export const rotateOutAnimation =
   "motion-rotate-out calc(var(--motion-rotate-duration) * var(--motion-rotate-perceptual-duration-multiplier)) var(--motion-rotate-timing) var(--motion-rotate-delay) both";
+export const rotateLoopAnimation = (type) =>
+  `motion-rotate-loop-${type} calc(var(--motion-rotate-duration) * var(--motion-rotate-perceptual-duration-multiplier)) var(--motion-rotate-timing) var(--motion-rotate-delay) both var(--motion-rotate-loop-count)`;
+
 export const filterInAnimation =
   "motion-filter-in calc(var(--motion-filter-duration) * var(--motion-filter-perceptual-duration-multiplier)) var(--motion-filter-timing) var(--motion-filter-delay) both";
 export const filterOutAnimation =
   "motion-filter-out calc(var(--motion-filter-duration) * var(--motion-filter-perceptual-duration-multiplier)) var(--motion-filter-timing) var(--motion-filter-delay) both";
+export const filterLoopAnimation = (type) =>
+  `motion-filter-loop-${type} calc(var(--motion-filter-duration) * var(--motion-filter-perceptual-duration-multiplier)) var(--motion-filter-timing) var(--motion-filter-delay) both var(--motion-filter-loop-count)`;
+
 export const opacityInAnimation =
   "motion-opacity-in calc(var(--motion-opacity-duration) * var(--motion-opacity-perceptual-duration-multiplier)) var(--motion-opacity-timing) var(--motion-opacity-delay) both";
 export const opacityOutAnimation =
   "motion-opacity-out calc(var(--motion-opacity-duration) * var(--motion-opacity-perceptual-duration-multiplier)) var(--motion-opacity-timing) var(--motion-opacity-delay) both";
+export const opacityLoopAnimation = (type) =>
+  `motion-opacity-loop-${type} calc(var(--motion-opacity-duration) * var(--motion-opacity-perceptual-duration-multiplier)) var(--motion-opacity-timing) var(--motion-opacity-delay) both var(--motion-opacity-loop-count)`;
+
 export const backgroundColorInAnimation =
   "motion-background-color-in calc(var(--motion-background-color-duration) * var(--motion-background-color-perceptual-duration-multiplier)) var(--motion-background-color-timing) var(--motion-background-color-delay) both";
 export const backgroundColorOutAnimation =
   "motion-background-color-out calc(var(--motion-background-color-duration) * var(--motion-background-color-perceptual-duration-multiplier)) var(--motion-background-color-timing) var(--motion-background-color-delay) both";
+export const backgroundColorLoopAnimation = (type) =>
+  `motion-background-color-loop-${type} calc(var(--motion-background-color-duration) * var(--motion-background-color-perceptual-duration-multiplier)) var(--motion-background-color-timing) var(--motion-background-color-delay) both var(--motion-background-color-loop-count)`;
+
 export const textColorInAnimation =
   "motion-text-color-in calc(var(--motion-text-color-duration) * var(--motion-text-color-perceptual-duration-multiplier)) var(--motion-text-color-timing) var(--motion-text-color-delay) both";
 export const textColorOutAnimation =
   "motion-text-color-out calc(var(--motion-text-color-duration) * var(--motion-text-color-perceptual-duration-multiplier)) var(--motion-text-color-timing) var(--motion-text-color-delay) both";
+export const textColorLoopAnimation = (type) =>
+  `motion-text-color-loop-${type} calc(var(--motion-text-color-duration) * var(--motion-text-color-perceptual-duration-multiplier)) var(--motion-text-color-timing) var(--motion-text-color-delay) both var(--motion-text-color-loop-count)`;
 
 /**
  * @param {import('tailwindcss/types/config').PluginAPI['matchUtilities']} matchUtilities
@@ -42,17 +62,17 @@ export function addBaseAnimations(matchUtilities, theme) {
         "--motion-origin-scale-x": value,
         "--motion-origin-scale-y": value,
         "--motion-scale-in-animation": scaleInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
       "motion-scale-x-in": (value) => ({
         "--motion-origin-scale-x": value,
         "--motion-scale-in-animation": scaleInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
       "motion-scale-y-in": (value) => ({
         "--motion-origin-scale-y": value,
         "--motion-scale-in-animation": scaleInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
 
       "motion-scale-out": (value) => ({
@@ -77,18 +97,56 @@ export function addBaseAnimations(matchUtilities, theme) {
     }
   );
 
+  // scale loop
+  matchUtilities(
+    {
+      "motion-scale-x-loop": (value, { modifier }) => ({
+        "--motion-loop-scale-x": value,
+        "--motion-scale-loop-animation": scaleLoopAnimation(
+          modifier || "mirror"
+        ),
+        animationComposition: "accumulate",
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+      "motion-scale-y-loop": (value, { modifier }) => ({
+        "--motion-loop-scale-y": value,
+        "--motion-scale-loop-animation": scaleLoopAnimation(
+          modifier || "mirror"
+        ),
+        animationComposition: "accumulate",
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+      "motion-scale-loop": (value, { modifier }) => ({
+        "--motion-loop-scale-x": value,
+        "--motion-loop-scale-y": value,
+        "--motion-scale-loop-animation": scaleLoopAnimation(
+          modifier || "mirror"
+        ),
+        animationComposition: "accumulate",
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+    },
+    {
+      values: theme("motionScale"),
+      modifiers: {
+        mirror: "mirror",
+        reset: "reset",
+      },
+    }
+  );
+
   // translate
   matchUtilities(
     {
       "motion-translate-x-in": (value) => ({
         "--motion-origin-translate-x": value,
         "--motion-translate-in-animation": translateInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
       "motion-translate-y-in": (value) => ({
         "--motion-origin-translate-y": value,
         "--motion-translate-in-animation": translateInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
 
       "motion-translate-x-out": (value) => ({
@@ -108,13 +166,47 @@ export function addBaseAnimations(matchUtilities, theme) {
     }
   );
 
+  // translate loop
+  matchUtilities(
+    {
+      "motion-translate-x-loop": (value, { modifier }) => {
+        return {
+          "--motion-loop-translate-x": value,
+          "--motion-translate-loop-animation": translateLoopAnimation(
+            modifier || "mirror"
+          ),
+          animationComposition: "accumulate",
+          animation: "var(--motion-all-loop-and-enter-animations)",
+        };
+      },
+      "motion-translate-y-loop": (value, { modifier }) => {
+        return {
+          "--motion-loop-translate-y": value,
+          "--motion-translate-loop-animation": translateLoopAnimation(
+            modifier || "mirror"
+          ),
+          animationComposition: "accumulate",
+          animation: "var(--motion-all-loop-and-enter-animations)",
+        };
+      },
+    },
+    {
+      values: theme("motionTranslate"),
+      supportsNegativeValues: true,
+      modifiers: {
+        mirror: "mirror",
+        reset: "reset",
+      },
+    }
+  );
+
   // rotate
   matchUtilities(
     {
       "motion-rotate-in": (value) => ({
         "--motion-origin-rotate": value,
         "--motion-rotate-in-animation": rotateInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
 
       "motion-rotate-out": (value) => ({
@@ -129,13 +221,35 @@ export function addBaseAnimations(matchUtilities, theme) {
     }
   );
 
+  // rotate loop
+  matchUtilities(
+    {
+      "motion-rotate-loop": (value, { modifier }) => ({
+        "--motion-loop-rotate": value,
+        "--motion-rotate-loop-animation": rotateLoopAnimation(
+          modifier || "mirror"
+        ),
+        animationComposition: "accumulate",
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+    },
+    {
+      values: theme("motionRotate"),
+      supportsNegativeValues: true,
+      modifiers: {
+        mirror: "mirror",
+        reset: "reset",
+      },
+    }
+  );
+
   // blur
   matchUtilities(
     {
       "motion-blur-in": (value) => ({
         "--motion-origin-blur": value,
         "--motion-filter-in-animation": filterInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
 
       "motion-blur-out": (value) => ({
@@ -149,13 +263,34 @@ export function addBaseAnimations(matchUtilities, theme) {
     }
   );
 
+  // blur loop
+  matchUtilities(
+    {
+      "motion-blur-loop": (value, { modifier }) => ({
+        "--motion-loop-blur": value,
+        "--motion-filter-loop-animation": filterLoopAnimation(
+          modifier || "mirror"
+        ),
+        animationComposition: "accumulate",
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+    },
+    {
+      values: theme("motionBlur"),
+      modifiers: {
+        mirror: "mirror",
+        reset: "reset",
+      },
+    }
+  );
+
   // grayscale
   matchUtilities(
     {
       "motion-grayscale-in": (value) => ({
         "--motion-origin-grayscale": value,
         "--motion-filter-in-animation": filterInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
 
       "motion-grayscale-out": (value) => ({
@@ -169,13 +304,34 @@ export function addBaseAnimations(matchUtilities, theme) {
     }
   );
 
+  // grayscale loop
+  matchUtilities(
+    {
+      "motion-grayscale-loop": (value, { modifier }) => ({
+        "--motion-loop-grayscale": value,
+        "--motion-filter-loop-animation": filterLoopAnimation(
+          modifier || "mirror"
+        ),
+        animationComposition: "accumulate",
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+    },
+    {
+      values: theme("motionGrayscale"),
+      modifiers: {
+        mirror: "mirror",
+        reset: "reset",
+      },
+    }
+  );
+
   // opacity
   matchUtilities(
     {
       "motion-opacity-in": (value) => ({
         "--motion-origin-opacity": value,
         "--motion-opacity-in-animation": opacityInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
 
       "motion-opacity-out": (value) => ({
@@ -189,13 +345,34 @@ export function addBaseAnimations(matchUtilities, theme) {
     }
   );
 
+  // opacity loop
+  matchUtilities(
+    {
+      "motion-opacity-loop": (value, { modifier }) => ({
+        "--motion-loop-opacity": value,
+        "--motion-opacity-loop-animation": opacityLoopAnimation(
+          modifier || "mirror"
+        ),
+        // no animation composition because it makes opacity not work
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+    },
+    {
+      values: theme("motionOpacity"),
+      modifiers: {
+        mirror: "mirror",
+        reset: "reset",
+      },
+    }
+  );
+
   // background-color
   matchUtilities(
     {
       "motion-bg-in": (value) => ({
         "--motion-origin-background-color": value,
         "--motion-background-color-in-animation": backgroundColorInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
 
       "motion-bg-out": (value) => ({
@@ -210,13 +387,34 @@ export function addBaseAnimations(matchUtilities, theme) {
     }
   );
 
+  // background-color loop
+  matchUtilities(
+    {
+      "motion-bg-loop": (value, { modifier }) => ({
+        "--motion-loop-background-color": value,
+        "--motion-background-color-loop-animation":
+          backgroundColorLoopAnimation(modifier || "mirror"),
+        // no animation composition because it makes colors add
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+    },
+    {
+      values: theme("motionBackgroundColor"),
+      type: "color",
+      modifiers: {
+        mirror: "mirror",
+        reset: "reset",
+      },
+    }
+  );
+
   // text-color
   matchUtilities(
     {
       "motion-text-in": (value) => ({
         "--motion-origin-text-color": value,
         "--motion-text-color-in-animation": textColorInAnimation,
-        animation: "var(--motion-all-enter-animations)",
+        animation: "var(--motion-all-loop-and-enter-animations)",
       }),
 
       "motion-text-out": (value) => ({
@@ -228,6 +426,28 @@ export function addBaseAnimations(matchUtilities, theme) {
     {
       values: theme("motionTextColor"),
       type: "color",
+    }
+  );
+
+  // text-color loop
+  matchUtilities(
+    {
+      "motion-text-loop": (value, { modifier }) => ({
+        "--motion-loop-text-color": value,
+        "--motion-text-color-loop-animation": textColorLoopAnimation(
+          modifier || "mirror"
+        ),
+        animationComposition: "accumulate",
+        animation: "var(--motion-all-loop-and-enter-animations)",
+      }),
+    },
+    {
+      values: theme("motionTextColor"),
+      type: "color",
+      modifiers: {
+        mirror: "mirror",
+        reset: "reset",
+      },
     }
   );
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -36,34 +36,47 @@ export default function addDefaults(addBase) {
     // https://github.com/tailwindlabs/tailwindcss/discussions/8747
     "@defaults tailwind-motion": {
       // enter animations origin values
-      "--motion-origin-scale-x": "1",
-      "--motion-origin-scale-y": "1",
-      "--motion-origin-translate-x": "0",
-      "--motion-origin-translate-y": "0",
-      "--motion-origin-rotate": "0",
-      "--motion-origin-blur": "0",
-      "--motion-origin-grayscale": "0",
-      "--motion-origin-opacity": "1",
+      "--motion-origin-scale-x": "100%",
+      "--motion-origin-scale-y": "100%",
+      "--motion-origin-translate-x": "0%",
+      "--motion-origin-translate-y": "0%",
+      "--motion-origin-rotate": "0deg",
+      "--motion-origin-blur": "0px",
+      "--motion-origin-grayscale": "0%",
+      "--motion-origin-opacity": "100%",
       "--motion-origin-background-color": "",
       "--motion-origin-text-color": "",
 
       // exit animations end values
-      "--motion-end-scale-x": "1",
-      "--motion-end-scale-y": "1",
-      "--motion-end-translate-x": "0",
-      "--motion-end-translate-y": "0",
-      "--motion-end-rotate": "0",
-      "--motion-end-blur": "0",
-      "--motion-end-grayscale": "0",
-      "--motion-end-opacity": "1",
+      "--motion-end-scale-x": "100%",
+      "--motion-end-scale-y": "100%",
+      "--motion-end-translate-x": "0%",
+      "--motion-end-translate-y": "0%",
+      "--motion-end-rotate": "0deg",
+      "--motion-end-blur": "0px",
+      "--motion-end-grayscale": "0%",
+      "--motion-end-opacity": "100%",
       "--motion-end-background-color": "",
       "--motion-end-text-color": "",
+
+      // loop animations values
+      "--motion-loop-scale-x": "100%",
+      "--motion-loop-scale-y": "100%",
+      "--motion-loop-translate-x": "0%",
+      "--motion-loop-translate-y": "0%",
+      "--motion-loop-rotate": "0deg",
+      "--motion-loop-blur": "0px",
+      "--motion-loop-grayscale": "0%",
+      "--motion-loop-opacity": "100%",
+      "--motion-loop-background-color": "",
+      "--motion-loop-text-color": "",
 
       // animation modifiers
       "--motion-duration": "750ms",
       "--motion-timing": "var(--motion-default-timing)",
       "--motion-perceptual-duration-multiplier": "1",
       "--motion-delay": "0ms",
+      "--motion-loop-count": "infinite",
 
       //animation modifiers for each animation
       "--motion-scale-duration": "var(--motion-duration)",
@@ -71,18 +84,21 @@ export default function addDefaults(addBase) {
       "--motion-scale-perceptual-duration-multiplier":
         "var(--motion-perceptual-duration-multiplier)",
       "--motion-scale-delay": "var(--motion-delay)",
+      "--motion-scale-loop-count": "var(--motion-loop-count)",
 
       "--motion-translate-duration": "var(--motion-duration)",
       "--motion-translate-timing": "var(--motion-timing)",
       "--motion-translate-perceptual-duration-multiplier":
         "var(--motion-perceptual-duration-multiplier)",
       "--motion-translate-delay": "var(--motion-delay)",
+      "--motion-translate-loop-count": "var(--motion-loop-count)",
 
       "--motion-rotate-duration": "var(--motion-duration)",
       "--motion-rotate-timing": "var(--motion-timing)",
       "--motion-rotate-perceptual-duration-multiplier":
         "var(--motion-perceptual-duration-multiplier)",
       "--motion-rotate-delay": "var(--motion-delay)",
+      "--motion-rotate-loop-count": "var(--motion-loop-count)",
 
       // filter groups blur and grayscale
       "--motion-filter-duration": "var(--motion-duration)",
@@ -90,24 +106,28 @@ export default function addDefaults(addBase) {
       "--motion-filter-perceptual-duration-multiplier":
         "var(--motion-perceptual-duration-multiplier)",
       "--motion-filter-delay": "var(--motion-delay)",
+      "--motion-filter-loop-count": "var(--motion-loop-count)",
 
       "--motion-opacity-duration": "var(--motion-duration)",
       "--motion-opacity-timing": "var(--motion-timing)",
       "--motion-opacity-perceptual-duration-multiplier":
         "var(--motion-perceptual-duration-multiplier)",
       "--motion-opacity-delay": "var(--motion-delay)",
+      "--motion-opacity-loop-count": "var(--motion-loop-count)",
 
       "--motion-background-color-duration": "var(--motion-duration)",
       "--motion-background-color-timing": "var(--motion-timing)",
       "--motion-background-color-perceptual-duration-multiplier":
         "var(--motion-perceptual-duration-multiplier)",
       "--motion-background-color-delay": "var(--motion-delay)",
+      "--motion-background-color-loop-count": "var(--motion-loop-count)",
 
       "--motion-text-color-duration": "var(--motion-duration)",
       "--motion-text-color-timing": "var(--motion-timing)",
       "--motion-text-color-perceptual-duration-multiplier":
         "var(--motion-perceptual-duration-multiplier)",
       "--motion-text-color-delay": "var(--motion-delay)",
+      "--motion-text-color-loop-count": "var(--motion-loop-count)",
 
       // default animations to none
       "--motion-scale-in-animation": "none",
@@ -126,11 +146,23 @@ export default function addDefaults(addBase) {
       "--motion-background-color-out-animation": "none",
       "--motion-text-color-out-animation": "none",
 
+      "--motion-scale-loop-animation": "none",
+      "--motion-translate-loop-animation": "none",
+      "--motion-rotate-loop-animation": "none",
+      "--motion-filter-loop-animation": "none",
+      "--motion-opacity-loop-animation": "none",
+      "--motion-background-color-loop-animation": "none",
+      "--motion-text-color-loop-animation": "none",
+
       // all animations
       "--motion-all-enter-animations":
         "var(--motion-scale-in-animation), var(--motion-translate-in-animation), var(--motion-rotate-in-animation), var(--motion-filter-in-animation), var(--motion-opacity-in-animation), var(--motion-background-color-in-animation), var(--motion-text-color-in-animation)",
       "--motion-all-exit-animations":
         "var(--motion-scale-out-animation), var(--motion-translate-out-animation), var(--motion-rotate-out-animation), var(--motion-filter-out-animation), var(--motion-opacity-out-animation), var(--motion-background-color-out-animation), var(--motion-text-color-out-animation)",
+      "--motion-all-loop-animations":
+        "var(--motion-scale-loop-animation), var(--motion-translate-loop-animation), var(--motion-rotate-loop-animation), var(--motion-filter-loop-animation), var(--motion-opacity-loop-animation), var(--motion-background-color-loop-animation), var(--motion-text-color-loop-animation)",
+      "--motion-all-loop-and-enter-animations":
+        "var(--motion-all-loop-animations), var(--motion-all-enter-animations)",
     },
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,9 @@ const pluginCreator = ({
 }) => {
   addDefaults(addBase);
   addKeyframes(addUtilities);
-  addModifiers(matchUtilities, theme);
-  addBaseAnimations(matchUtilities, theme);
   addPresets(addComponents, matchComponents, theme);
+  addBaseAnimations(matchUtilities, theme);
+  addModifiers(matchUtilities, addUtilities, theme);
 };
 
 /** @type {import('tailwindcss/types/config').Config}*/

--- a/src/keyframes.js
+++ b/src/keyframes.js
@@ -20,6 +20,22 @@ export default function addKeyframes(addUtilities) {
           scale: "var(--motion-end-scale-x) var(--motion-end-scale-y)",
         },
       },
+      "@keyframes motion-scale-loop-mirror": {
+        "0%, 100%": {
+          scale: "1 1",
+        },
+        "50%": {
+          scale: "var(--motion-loop-scale-x) var(--motion-loop-scale-y)",
+        },
+      },
+      "@keyframes motion-scale-loop-reset": {
+        "0%": {
+          scale: "1 1",
+        },
+        "100%": {
+          scale: "var(--motion-loop-scale-x) var(--motion-loop-scale-y)",
+        },
+      },
       "@keyframes motion-translate-in": {
         "0%": {
           translate:
@@ -38,6 +54,24 @@ export default function addKeyframes(addUtilities) {
             "var(--motion-end-translate-x) var(--motion-end-translate-y)",
         },
       },
+      "@keyframes motion-translate-loop-mirror": {
+        "0%, 100%": {
+          translate: "0 0",
+        },
+        "50%": {
+          translate:
+            "var(--motion-loop-translate-x) var(--motion-loop-translate-y)",
+        },
+      },
+      "@keyframes motion-translate-loop-reset": {
+        "0%": {
+          translate: "0 0",
+        },
+        "100%": {
+          translate:
+            "var(--motion-loop-translate-x) var(--motion-loop-translate-y)",
+        },
+      },
       "@keyframes motion-rotate-in": {
         "0%": {
           rotate: "var(--motion-origin-rotate)",
@@ -52,6 +86,20 @@ export default function addKeyframes(addUtilities) {
         },
         "100%": {
           rotate: "var(--motion-end-rotate)",
+        },
+      },
+      "@keyframes motion-rotate-loop-mirror": {
+        "0%, 100%": {
+          rotate: "0deg",
+        },
+        "50%": {
+          rotate: "var(--motion-loop-rotate)",
+        },
+      },
+      "@keyframes motion-rotate-loop-reset": {
+        "0%": {},
+        "100%": {
+          rotate: "var(--motion-loop-rotate)",
         },
       },
     },
@@ -73,6 +121,24 @@ export default function addKeyframes(addUtilities) {
           "blur(var(--motion-end-blur)) grayscale(var(--motion-end-grayscale))",
       },
     },
+    "@keyframes motion-filter-loop-mirror": {
+      "0%, 100%": {
+        filter: "blur(0) grayscale(0)",
+      },
+      "50%": {
+        filter:
+          "blur(var(--motion-loop-blur)) grayscale(var(--motion-loop-grayscale))",
+      },
+    },
+    "@keyframes motion-filter-loop-reset": {
+      "0%": {
+        filter: "blur(0) grayscale(0)",
+      },
+      "100%": {
+        filter:
+          "blur(var(--motion-loop-blur)) grayscale(var(--motion-loop-grayscale))",
+      },
+    },
     "@keyframes motion-opacity-in": {
       "0%": {
         opacity: "var(--motion-origin-opacity)",
@@ -81,6 +147,18 @@ export default function addKeyframes(addUtilities) {
     "@keyframes motion-opacity-out": {
       "100%": {
         opacity: "var(--motion-end-opacity)",
+      },
+    },
+    "@keyframes motion-opacity-loop-mirror": {
+      "0%, 100%": {},
+      "50%": {
+        opacity: "var(--motion-loop-opacity)",
+      },
+    },
+    "@keyframes motion-opacity-loop-reset": {
+      "0%": {},
+      "100%": {
+        opacity: "var(--motion-loop-opacity)",
       },
     },
     "@keyframes motion-background-color-in": {
@@ -93,6 +171,18 @@ export default function addKeyframes(addUtilities) {
         backgroundColor: "var(--motion-end-background-color)",
       },
     },
+    "@keyframes motion-background-color-loop-mirror": {
+      "0%, 100%": {},
+      "50%": {
+        backgroundColor: "var(--motion-loop-background-color)",
+      },
+    },
+    "@keyframes motion-background-color-loop-reset": {
+      "0%": {},
+      "100%": {
+        backgroundColor: "var(--motion-loop-background-color)",
+      },
+    },
     "@keyframes motion-text-color-in": {
       "0%": {
         color: "var(--motion-origin-text-color)",
@@ -101,6 +191,18 @@ export default function addKeyframes(addUtilities) {
     "@keyframes motion-text-color-out": {
       "100%": {
         color: "var(--motion-end-text-color)",
+      },
+    },
+    "@keyframes motion-text-color-loop-mirror": {
+      "0%, 100%": {},
+      "50%": {
+        color: "var(--motion-loop-text-color)",
+      },
+    },
+    "@keyframes motion-text-color-loop-reset": {
+      "0%": {},
+      "100%": {
+        color: "var(--motion-loop-text-color)",
       },
     },
   });

--- a/src/modifiers.js
+++ b/src/modifiers.js
@@ -10,9 +10,10 @@ export const springPerceptualMultipliers = {
 
 /**
  * @param {import('tailwindcss/types/config').PluginAPI['matchUtilities']} matchUtilities
+ * @param {import('tailwindcss/types/config').PluginAPI['addUtilities']} addUtilities
  * @param {import('tailwindcss/types/config').PluginAPI['theme']} theme
  * */
-export function addModifiers(matchUtilities, theme) {
+export function addModifiers(matchUtilities, addUtilities, theme) {
   // duration
   matchUtilities(
     {
@@ -83,8 +84,7 @@ export function addModifiers(matchUtilities, theme) {
       },
     },
     {
-      // use the same values as the duration
-      values: theme("animationDuration"),
+      values: theme("animationDelay"),
       modifiers: {
         scale: "scale",
         translate: "translate",
@@ -193,6 +193,70 @@ export function addModifiers(matchUtilities, theme) {
       },
     }
   );
+
+  // animation play state
+  addUtilities({
+    ".motion-paused": {
+      animationPlayState: "paused",
+      "&::before": {
+        animationPlayState: "paused",
+      },
+      "&::after": {
+        animationPlayState: "paused",
+      },
+    },
+    ".motion-running": {
+      animationPlayState: "running",
+      "&::before": {
+        animationPlayState: "running",
+      },
+      "&::after": {
+        animationPlayState: "running",
+      },
+    },
+  });
+
+  // loop
+  matchUtilities(
+    {
+      "motion-loop": (value, { modifier }) => {
+        switch (modifier) {
+          case "scale":
+            return { "--motion-scale-loop-count": value };
+          case "translate":
+            return { "--motion-translate-loop-count": value };
+          case "rotate":
+            return { "--motion-rotate-loop-count": value };
+          case "blur":
+          case "grayscale":
+            return { "--motion-filter-loop-count": value };
+          case "opacity":
+            return { "--motion-opacity-loop-count": value };
+          case "background":
+            return { "--motion-background-color-loop-count": value };
+          case "text":
+            return { "--motion-text-color-loop-count": value };
+          default:
+            return {
+              "--motion-loop-count": value,
+            };
+        }
+      },
+    },
+    {
+      values: theme("animationLoopCount"),
+      modifiers: {
+        scale: "scale",
+        translate: "translate",
+        rotate: "rotate",
+        blur: "blur",
+        grayscale: "grayscale",
+        opacity: "opacity",
+        background: "background",
+        text: "text",
+      },
+    }
+  );
 }
 
 export const modifiersTheme = {
@@ -226,4 +290,12 @@ export const modifiersTheme = {
     1500: "1500ms",
     2000: "2000ms",
   }),
+  animationDelay: (theme) => ({
+    ...theme("animationDuration"),
+  }),
+  animationLoopCount: {
+    infinite: "infinite",
+    once: "1",
+    twice: "2",
+  },
 };

--- a/src/presets.js
+++ b/src/presets.js
@@ -1,9 +1,13 @@
 import {
   filterInAnimation,
   opacityInAnimation,
+  opacityLoopAnimation,
   rotateInAnimation,
+  rotateLoopAnimation,
   scaleInAnimation,
+  scaleLoopAnimation,
   translateInAnimation,
+  translateLoopAnimation,
 } from "./baseAnimations";
 import { springPerceptualMultipliers } from "./modifiers";
 
@@ -25,7 +29,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-duration": durations[size],
           "--motion-opacity-in-animation": opacityInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-slide-right": (size) => {
@@ -39,7 +43,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-slide-left": (size) => {
@@ -53,7 +57,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-slide-up": (size) => {
@@ -67,7 +71,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-slide-down": (size) => {
@@ -81,7 +85,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-slide-up-right": (size) => {
@@ -96,7 +100,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-slide-up-left": (size) => {
@@ -111,7 +115,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-slide-down-left": (size) => {
@@ -126,7 +130,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-slide-down-right": (size) => {
@@ -141,7 +145,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
 
@@ -156,7 +160,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
 
@@ -178,7 +182,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-blur-left": (size) => {
@@ -199,7 +203,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-blur-up": (size) => {
@@ -220,7 +224,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
       "motion-preset-blur-down": (size) => {
@@ -241,7 +245,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
     },
@@ -280,7 +284,7 @@ export function addPresets(addComponents, matchComponents, theme) {
           "--motion-origin-opacity": 0,
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-enter-animations)",
+          animation: "var(--motion-all-loop-and-enter-animations)",
         };
       },
     },
@@ -305,7 +309,7 @@ export function addPresets(addComponents, matchComponents, theme) {
       "--motion-origin-translate-y": "-25%",
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-translate-in-animation": translateInAnimation,
-      animation: "var(--motion-all-enter-animations)",
+      animation: "var(--motion-all-loop-and-enter-animations)",
     },
   });
 
@@ -316,7 +320,7 @@ export function addPresets(addComponents, matchComponents, theme) {
       "--motion-origin-opacity": 0,
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-scale-in-animation": scaleInAnimation,
-      animation: "var(--motion-all-enter-animations)",
+      animation: "var(--motion-all-loop-and-enter-animations)",
     },
   });
 
@@ -327,7 +331,7 @@ export function addPresets(addComponents, matchComponents, theme) {
       "--motion-origin-opacity": 0,
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-scale-in-animation": scaleInAnimation,
-      animation: "var(--motion-all-enter-animations)",
+      animation: "var(--motion-all-loop-and-enter-animations)",
     },
   });
 
@@ -341,7 +345,7 @@ export function addPresets(addComponents, matchComponents, theme) {
         springPerceptualMultipliers["var(--motion-spring-bouncier)"],
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-scale-in-animation": scaleInAnimation,
-      animation: "var(--motion-all-enter-animations)",
+      animation: "var(--motion-all-loop-and-enter-animations)",
     },
   });
 
@@ -355,7 +359,7 @@ export function addPresets(addComponents, matchComponents, theme) {
         springPerceptualMultipliers["var(--motion-spring-bouncier)"],
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-scale-in-animation": scaleInAnimation,
-      animation: "var(--motion-all-enter-animations)",
+      animation: "var(--motion-all-loop-and-enter-animations)",
     },
   });
 
@@ -369,7 +373,7 @@ export function addPresets(addComponents, matchComponents, theme) {
         springPerceptualMultipliers["var(--motion-spring-bounciest)"],
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-rotate-in-animation": rotateInAnimation,
-      animation: "var(--motion-all-enter-animations)",
+      animation: "var(--motion-all-loop-and-enter-animations)",
     },
   });
 
@@ -388,7 +392,7 @@ export function addPresets(addComponents, matchComponents, theme) {
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-rotate-in-animation": rotateInAnimation,
       "--motion-translate-in-animation": translateInAnimation,
-      animation: "var(--motion-all-enter-animations)",
+      animation: "var(--motion-all-loop-and-enter-animations)",
     },
   });
 
@@ -402,7 +406,7 @@ export function addPresets(addComponents, matchComponents, theme) {
       zIndex: "1",
       margin: "0",
       animation:
-        "RomboConfettiPop var(--motion-duration) var(--motion-timing)  both !important",
+        "RomboConfettiPop var(--motion-duration) var(--motion-timing)  both",
 
       "@keyframes RomboConfettiPop": {
         "0%": {
@@ -511,11 +515,133 @@ export function addPresets(addComponents, matchComponents, theme) {
     },
   });
 
+  matchComponents(
+    {
+      "motion-preset-pulse": (size) => {
+        const sizes = {
+          sm: "1.1",
+          md: "1.25",
+          lg: "1.5",
+        };
+        return {
+          "--motion-loop-scale-x": sizes[size],
+          "--motion-loop-scale-y": sizes[size],
+          "--motion-ease": "cubic-bezier(0.4, 0, 0.2, 1)",
+          "--motion-scale-loop-animation": scaleLoopAnimation("mirror"),
+          animation: "var(--motion-all-loop-and-enter-animations)",
+        };
+      },
+      "motion-preset-wobble": (size) => {
+        const sizes = {
+          sm: "5%",
+          md: "15%",
+          lg: "25%",
+        };
+        return {
+          "--motion-loop-translate-x": sizes[size],
+          "--motion-ease": "cubic-bezier(0.4, 0, 0.2, 1)",
+          "--motion-translate-loop-animation": translateLoopAnimation("mirror"),
+          animation: "var(--motion-all-loop-and-enter-animations)",
+        };
+      },
+      "motion-preset-seesaw": (size) => {
+        const sizes = {
+          sm: "3deg",
+          md: "6deg",
+          lg: "12deg",
+        };
+        return {
+          "--motion-loop-rotate": sizes[size],
+          "--motion-rotate-loop-animation": rotateLoopAnimation("mirror"),
+          "--motion-timing": "var(--motion-spring-bounciest)",
+          "--motion-perceptual-duration-multiplier":
+            springPerceptualMultipliers["var(--motion-spring-bounciest)"],
+          animation: "var(--motion-all-loop-and-enter-animations)",
+        };
+      },
+      "motion-preset-oscillate": (size) => {
+        const sizes = {
+          sm: "5%",
+          md: "15%",
+          lg: "25%",
+        };
+        return {
+          "--motion-loop-translate-y": sizes[size],
+          "--motion-ease": "cubic-bezier(0.4, 0, 0.2, 1)",
+          "--motion-translate-loop-animation": translateLoopAnimation("mirror"),
+          animation: "var(--motion-all-loop-and-enter-animations)",
+        };
+      },
+      "motion-preset-stretch": (size) => {
+        const xSizes = {
+          sm: "95%",
+          md: "85%",
+          lg: "75%",
+        };
+        const ySizes = {
+          sm: "105%",
+          md: "115%",
+          lg: "125%",
+        };
+        return {
+          "--motion-loop-scale-x": xSizes[size],
+          "--motion-loop-scale-y": ySizes[size],
+          "--motion-ease": "var(--motion-spring-bouncier)",
+          "--motion-perceptual-duration-multiplier":
+            springPerceptualMultipliers["var(--motion-spring-bouncier)"],
+          "--motion-scale-loop-animation": scaleLoopAnimation("mirror"),
+          animation: "var(--motion-all-loop-and-enter-animations)",
+        };
+      },
+      "motion-preset-float": (size) => {
+        const sizes = {
+          sm: "50%",
+          md: "100%",
+          lg: "150%",
+        };
+        return {
+          "--motion-loop-translate-y": sizes[size],
+          "--motion-ease": "var(--motion-spring-bouncier)",
+          "--motion-perceptual-duration-multiplier":
+            springPerceptualMultipliers["var(--motion-spring-bouncier)"],
+          "--motion-duration": "2000ms",
+          "--motion-translate-loop-animation": translateLoopAnimation("mirror"),
+          animation: "var(--motion-all-loop-and-enter-animations)",
+        };
+      },
+    },
+    {
+      values: {
+        sm: "sm",
+        md: "md",
+        lg: "lg",
+        DEFAULT: "md",
+      },
+    }
+  );
+
+  addComponents({
+    ".motion-preset-spin": {
+      "--motion-loop-rotate": "360deg",
+      "--motion-timing": "linear",
+      "--motion-rotate-loop-animation": rotateLoopAnimation("reset"),
+      animation: "var(--motion-all-loop-and-enter-animations)",
+    },
+  });
+
+  addComponents({
+    ".motion-preset-blink": {
+      "--motion-loop-opacity": 0,
+      "--motion-opacity-loop-animation": opacityLoopAnimation("mirror"),
+      animation: "var(--motion-all-loop-and-enter-animations)",
+    },
+  });
+
   matchComponents({
     "motion-preset-typewriter": (value) => ({
       "--motion-duration": "2000ms",
       "--motion-typewriter-value": `${value}ch`,
-      animation: `typing var(--motion-duration) steps(${value}) infinite, blink 0.4s step-end infinite alternate`,
+      animation: `typing var(--motion-duration) steps(${value}) var(--motion-loop-count), blink 0.4s step-end infinite alternate`,
       whiteSpace: "nowrap",
       borderRight: "2px solid",
       fontFamily: "monospace",
@@ -523,7 +649,7 @@ export function addPresets(addComponents, matchComponents, theme) {
 
       "@media screen and (prefers-reduced-motion: no-preference)": {
         "@keyframes typing": {
-          "0%, 10%, 90%, 100%": {
+          "10%, 90%": {
             width: "0",
           },
           "40%, 60%": {

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,9 +4,10 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <div class="flex justify-center items-center h-screen flex-col gap-6">
-      <h1 class="">Hello Tailwind Motion</h1>
-      <div class="size-36 bg-emerald-700 motion-preset-rebound-down"></div>
+    <div
+      class="relative text-white text-6xl flex text-center font-black justify-center items-center h-screen flex-col bg-black"
+    >
+      <div class="motion-translate-x-loop-[5%] motion-duration-75">🚀</div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
- Loop Base Animations:
  - loops can now be applied to existing base animations (e.g., motion-translate-y-loop-25).
  - Modifiers such as /mirror (default) and /reset enable control over the direction and reset behavior of the loop.
  - Loop count utilities (motion-loop-once, motion-loop-twice, motion-loop-infinite) allow specification of how many times the animation repeats.
- New Loop Animation Presets: Added presets for pulse, wobble, seesaw, oscillate, stretch, float, spin, and blink.
- Animation Play State: New utilities motion-paused and motion-running allow pausing and resuming animations.
- Added resources to readme