### PR TITLE
changed flattenColorPalette.js to flattenColorPalette

### DIFF
--- a/src/baseAnimations.ts
+++ b/src/baseAnimations.ts
@@ -1,4 +1,4 @@
-import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette.js";
+import flattenColorPalette from "tailwindcss/lib/util/flattenColorPalette";
 import type { Config, PluginAPI } from "tailwindcss/types/config.js";
 
 type ThemeConfig = {

--- a/src/types/tailwind-internals.d.ts
+++ b/src/types/tailwind-internals.d.ts
@@ -1,5 +1,5 @@
 // src/types/tailwind-internals.d.ts
-declare module "tailwindcss/lib/util/flattenColorPalette.js" {
+declare module "tailwindcss/lib/util/flattenColorPalette" {
   type ColorValue = string | { [key: string]: string };
   type NestedColors = {
     [key: string]: ColorValue | NestedColors;


### PR DESCRIPTION
Tailwind v4
package.json exports flattenColorPalette not flattenColorPalette.js so node js was throwing an error `Internal server error: Package subpath './lib/util/flattenColorPalette.js' is not defined by "exports" in ~/node_modules/tailwindcss/package.json``

changing flattenColorPalette.js to flattenColorPalette in baseAnimations.ts and tailwind-internals.d.ts and building the project fixes the issue.