### PR TITLE
Change aproach to defaults

### DIFF
--- a/src/baseAnimations.ts
+++ b/src/baseAnimations.ts
@@ -18,68 +18,79 @@ type ThemeConfig = {
   scale: Record<string, string>;
 };
 
+const allEnterAnimations =
+  "var(--motion-scale-in-animation), var(--motion-translate-in-animation), var(--motion-rotate-in-animation), var(--motion-filter-in-animation), var(--motion-opacity-in-animation), var(--motion-background-color-in-animation), var(--motion-text-color-in-animation)";
+
+const allExitAnimations =
+  "var(--motion-scale-out-animation), var(--motion-translate-out-animation), var(--motion-rotate-out-animation), var(--motion-filter-out-animation), var(--motion-opacity-out-animation), var(--motion-background-color-out-animation), var(--motion-text-color-out-animation)";
+
+const allLoopAnimations =
+  "var(--motion-scale-loop-animation), var(--motion-translate-loop-animation), var(--motion-rotate-loop-animation), var(--motion-filter-loop-animation), var(--motion-opacity-loop-animation), var(--motion-background-color-loop-animation), var(--motion-text-color-loop-animation)";
+
+const allLoopAndEnterAnimations = `${allEnterAnimations}, ${allLoopAnimations}`;
+
 // animation strings
 export const scaleInAnimation =
-  "motion-scale-in calc(var(--motion-scale-duration) * var(--motion-scale-perceptual-duration-multiplier)) var(--motion-scale-timing) var(--motion-scale-delay) both";
+  "motion-scale-in calc(var(--motion-scale-duration, var(--motion-duration)) * var(--motion-scale-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-scale-timing, var(--motion-timing)) var(--motion-scale-delay, var(--motion-delay)) both";
 
 export const scaleOutAnimation =
-  "motion-scale-out calc(var(--motion-scale-duration) * var(--motion-scale-perceptual-duration-multiplier)) var(--motion-scale-timing) var(--motion-scale-delay) both";
+  "motion-scale-out calc(var(--motion-scale-duration, var(--motion-duration)) * var(--motion-scale-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-scale-timing, var(--motion-timing)) var(--motion-scale-delay, var(--motion-delay)) both";
 
 export const scaleLoopAnimation = (type: string) =>
-  `motion-scale-loop-${type} calc(var(--motion-scale-duration) * var(--motion-scale-perceptual-duration-multiplier)) var(--motion-scale-timing) var(--motion-scale-delay) both var(--motion-scale-loop-count)`;
+  `motion-scale-loop-${type} calc(var(--motion-scale-duration, var(--motion-duration)) * var(--motion-scale-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-scale-timing, var(--motion-timing)) var(--motion-scale-delay, var(--motion-delay)) both var(--motion-scale-loop-count, var(--motion-loop-count))`;
 
 export const translateInAnimation =
-  "motion-translate-in calc(var(--motion-translate-duration) * var(--motion-translate-perceptual-duration-multiplier)) var(--motion-translate-timing) var(--motion-translate-delay) both";
+  "motion-translate-in calc(var(--motion-translate-duration, var(--motion-duration)) * var(--motion-translate-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-translate-timing, var(--motion-timing)) var(--motion-translate-delay, var(--motion-delay)) both";
 
 export const translateOutAnimation =
-  "motion-translate-out calc(var(--motion-translate-duration) * var(--motion-translate-perceptual-duration-multiplier)) var(--motion-translate-timing) var(--motion-translate-delay) both";
+  "motion-translate-out calc(var(--motion-translate-duration, var(--motion-duration)) * var(--motion-translate-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-translate-timing, var(--motion-timing)) var(--motion-translate-delay, var(--motion-delay)) both";
 
 export const translateLoopAnimation = (type: string) =>
-  `motion-translate-loop-${type} calc(var(--motion-translate-duration) * var(--motion-translate-perceptual-duration-multiplier)) var(--motion-translate-timing) var(--motion-translate-delay) both var(--motion-translate-loop-count)`;
+  `motion-translate-loop-${type} calc(var(--motion-translate-duration, var(--motion-duration)) * var(--motion-translate-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-translate-timing, var(--motion-timing)) var(--motion-translate-delay, var(--motion-delay)) both var(--motion-translate-loop-count, var(--motion-loop-count))`;
 
 export const rotateInAnimation =
-  "motion-rotate-in calc(var(--motion-rotate-duration) * var(--motion-rotate-perceptual-duration-multiplier)) var(--motion-rotate-timing) var(--motion-rotate-delay) both";
+  "motion-rotate-in calc(var(--motion-rotate-duration, var(--motion-duration)) * var(--motion-rotate-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-rotate-timing, var(--motion-timing)) var(--motion-rotate-delay, var(--motion-delay)) both";
 
 export const rotateOutAnimation =
-  "motion-rotate-out calc(var(--motion-rotate-duration) * var(--motion-rotate-perceptual-duration-multiplier)) var(--motion-rotate-timing) var(--motion-rotate-delay) both";
+  "motion-rotate-out calc(var(--motion-rotate-duration, var(--motion-duration)) * var(--motion-rotate-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-rotate-timing, var(--motion-timing)) var(--motion-rotate-delay, var(--motion-delay)) both";
 
 export const rotateLoopAnimation = (type: string) =>
-  `motion-rotate-loop-${type} calc(var(--motion-rotate-duration) * var(--motion-rotate-perceptual-duration-multiplier)) var(--motion-rotate-timing) var(--motion-rotate-delay) both var(--motion-rotate-loop-count)`;
+  `motion-rotate-loop-${type} calc(var(--motion-rotate-duration, var(--motion-duration)) * var(--motion-rotate-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-rotate-timing, var(--motion-timing)) var(--motion-rotate-delay, var(--motion-delay)) both var(--motion-rotate-loop-count, var(--motion-loop-count))`;
 
 export const filterInAnimation =
-  "motion-filter-in calc(var(--motion-filter-duration) * var(--motion-filter-perceptual-duration-multiplier)) var(--motion-filter-timing) var(--motion-filter-delay) both";
+  "motion-filter-in calc(var(--motion-filter-duration, var(--motion-duration)) * var(--motion-filter-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-filter-timing, var(--motion-timing)) var(--motion-filter-delay, var(--motion-delay)) both";
 export const filterOutAnimation =
-  "motion-filter-out calc(var(--motion-filter-duration) * var(--motion-filter-perceptual-duration-multiplier)) var(--motion-filter-timing) var(--motion-filter-delay) both";
+  "motion-filter-out calc(var(--motion-filter-duration, var(--motion-duration)) * var(--motion-filter-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-filter-timing, var(--motion-timing)) var(--motion-filter-delay, var(--motion-delay)) both";
 
 export const filterLoopAnimation = (type: string) =>
-  `motion-filter-loop-${type} calc(var(--motion-filter-duration) * var(--motion-filter-perceptual-duration-multiplier)) var(--motion-filter-timing) var(--motion-filter-delay) both var(--motion-filter-loop-count)`;
+  `motion-filter-loop-${type} calc(var(--motion-filter-duration, var(--motion-duration)) * var(--motion-filter-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-filter-timing, var(--motion-timing)) var(--motion-filter-delay, var(--motion-delay)) both var(--motion-filter-loop-count, var(--motion-loop-count))`;
 
 export const opacityInAnimation =
-  "motion-opacity-in calc(var(--motion-opacity-duration) * var(--motion-opacity-perceptual-duration-multiplier)) var(--motion-opacity-timing) var(--motion-opacity-delay) both";
+  "motion-opacity-in calc(var(--motion-opacity-duration, var(--motion-duration)) * var(--motion-opacity-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-opacity-timing, var(--motion-timing)) var(--motion-opacity-delay, var(--motion-delay)) both";
 
 export const opacityOutAnimation =
-  "motion-opacity-out calc(var(--motion-opacity-duration) * var(--motion-opacity-perceptual-duration-multiplier)) var(--motion-opacity-timing) var(--motion-opacity-delay) both";
+  "motion-opacity-out calc(var(--motion-opacity-duration, var(--motion-duration)) * var(--motion-opacity-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-opacity-timing, var(--motion-timing)) var(--motion-opacity-delay, var(--motion-delay)) both";
 
 export const opacityLoopAnimation = (type: string) =>
-  `motion-opacity-loop-${type} calc(var(--motion-opacity-duration) * var(--motion-opacity-perceptual-duration-multiplier)) var(--motion-opacity-timing) var(--motion-opacity-delay) both var(--motion-opacity-loop-count)`;
+  `motion-opacity-loop-${type} calc(var(--motion-opacity-duration, var(--motion-duration)) * var(--motion-opacity-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-opacity-timing, var(--motion-timing)) var(--motion-opacity-delay, var(--motion-delay)) both var(--motion-opacity-loop-count, var(--motion-loop-count))`;
 
 export const backgroundColorInAnimation =
-  "motion-background-color-in calc(var(--motion-background-color-duration) * var(--motion-background-color-perceptual-duration-multiplier)) var(--motion-background-color-timing) var(--motion-background-color-delay) both";
+  "motion-background-color-in calc(var(--motion-background-color-duration, var(--motion-duration)) * var(--motion-background-color-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-background-color-timing, var(--motion-timing)) var(--motion-background-color-delay, var(--motion-delay)) both";
 
 export const backgroundColorOutAnimation =
-  "motion-background-color-out calc(var(--motion-background-color-duration) * var(--motion-background-color-perceptual-duration-multiplier)) var(--motion-background-color-timing) var(--motion-background-color-delay) both";
+  "motion-background-color-out calc(var(--motion-background-color-duration, var(--motion-duration)) * var(--motion-background-color-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-background-color-timing, var(--motion-timing)) var(--motion-background-color-delay, var(--motion-delay)) both";
 
 export const backgroundColorLoopAnimation = (type: string) =>
-  `motion-background-color-loop-${type} calc(var(--motion-background-color-duration) * var(--motion-background-color-perceptual-duration-multiplier)) var(--motion-background-color-timing) var(--motion-background-color-delay) both var(--motion-background-color-loop-count)`;
+  `motion-background-color-loop-${type} calc(var(--motion-background-color-duration, var(--motion-duration)) * var(--motion-background-color-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-background-color-timing, var(--motion-timing)) var(--motion-background-color-delay, var(--motion-delay)) both var(--motion-background-color-loop-count, var(--motion-loop-count))`;
 
 export const textColorInAnimation =
-  "motion-text-color-in calc(var(--motion-text-color-duration) * var(--motion-text-color-perceptual-duration-multiplier)) var(--motion-text-color-timing) var(--motion-text-color-delay) both";
+  "motion-text-color-in calc(var(--motion-text-color-duration, var(--motion-duration)) * var(--motion-text-color-perceptual-duration-multiplier, var(--motion-perceptual-duration-multiplier))) var(--motion-text-color-timing, var(--motion-timing)) var(--motion-text-color-delay, var(--motion-delay)) both";
 
 export const textColorOutAnimation =
-  "motion-text-color-out calc(var(--motion-text-color-duration) * var(--motion-text-color-perceptual-duration-multiplier)) var(--motion-text-color-timing) var(--motion-text-color-delay) both";
+  "motion-text-color-out calc(var(--motion-text-color-duration, --motion-duration) * var(--motion-text-color-perceptual-duration-multiplier, --motion-perceptual-duration-multiplier)) var(--motion-text-color-timing, --motion-timing) var(--motion-text-color-delay, --motion-delay) both";
 
 export const textColorLoopAnimation = (type: string) =>
-  `motion-text-color-loop-${type} calc(var(--motion-text-color-duration) * var(--motion-text-color-perceptual-duration-multiplier)) var(--motion-text-color-timing) var(--motion-text-color-delay) both var(--motion-text-color-loop-count)`;
+  `motion-text-color-loop-${type} calc(var(--motion-text-color-duration, --motion-duration) * var(--motion-text-color-perceptual-duration-multiplier, --motion-perceptual-duration-multiplier)) var(--motion-text-color-timing, --motion-timing) var(--motion-text-color-delay, --motion-delay) both var(--motion-text-color-loop-count, --motion-loop-count)`;
 
 export function addBaseAnimations(
   matchUtilities: PluginAPI["matchUtilities"],
@@ -92,34 +103,34 @@ export function addBaseAnimations(
         "--motion-origin-scale-x": value,
         "--motion-origin-scale-y": value,
         "--motion-scale-in-animation": scaleInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
       "motion-scale-x-in": (value) => ({
         "--motion-origin-scale-x": value,
         "--motion-scale-in-animation": scaleInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
       "motion-scale-y-in": (value) => ({
         "--motion-origin-scale-y": value,
         "--motion-scale-in-animation": scaleInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
 
       "motion-scale-out": (value) => ({
         "--motion-end-scale-x": value,
         "--motion-end-scale-y": value,
         "--motion-scale-out-animation": scaleOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
       "motion-scale-x-out": (value) => ({
         "--motion-end-scale-x": value,
         "--motion-scale-out-animation": scaleOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
       "motion-scale-y-out": (value) => ({
         "--motion-end-scale-y": value,
         "--motion-scale-out-animation": scaleOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
     },
     {
@@ -136,7 +147,7 @@ export function addBaseAnimations(
           modifier || "mirror"
         ),
         animationComposition: "accumulate",
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
       "motion-scale-y-loop": (value, { modifier }) => ({
         "--motion-loop-scale-y": value,
@@ -144,7 +155,7 @@ export function addBaseAnimations(
           modifier || "mirror"
         ),
         animationComposition: "accumulate",
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
       "motion-scale-loop": (value, { modifier }) => ({
         "--motion-loop-scale-x": value,
@@ -153,7 +164,7 @@ export function addBaseAnimations(
           modifier || "mirror"
         ),
         animationComposition: "accumulate",
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
     },
     {
@@ -171,23 +182,23 @@ export function addBaseAnimations(
       "motion-translate-x-in": (value) => ({
         "--motion-origin-translate-x": value,
         "--motion-translate-in-animation": translateInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
       "motion-translate-y-in": (value) => ({
         "--motion-origin-translate-y": value,
         "--motion-translate-in-animation": translateInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
 
       "motion-translate-x-out": (value) => ({
         "--motion-end-translate-x": value,
         "--motion-translate-out-animation": translateOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
       "motion-translate-y-out": (value) => ({
         "--motion-end-translate-y": value,
         "--motion-translate-out-animation": translateOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
     },
     {
@@ -206,7 +217,7 @@ export function addBaseAnimations(
             modifier || "mirror"
           ),
           animationComposition: "accumulate",
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-translate-y-loop": (value, { modifier }) => {
@@ -216,7 +227,7 @@ export function addBaseAnimations(
             modifier || "mirror"
           ),
           animationComposition: "accumulate",
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
     },
@@ -236,13 +247,13 @@ export function addBaseAnimations(
       "motion-rotate-in": (value) => ({
         "--motion-origin-rotate": value,
         "--motion-rotate-in-animation": rotateInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
 
       "motion-rotate-out": (value) => ({
         "--motion-end-rotate": value,
         "--motion-rotate-out-animation": rotateOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
     },
     {
@@ -260,7 +271,7 @@ export function addBaseAnimations(
           modifier || "mirror"
         ),
         animationComposition: "accumulate",
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
     },
     {
@@ -279,13 +290,13 @@ export function addBaseAnimations(
       "motion-blur-in": (value) => ({
         "--motion-origin-blur": value,
         "--motion-filter-in-animation": filterInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
 
       "motion-blur-out": (value) => ({
         "--motion-end-blur": value,
         "--motion-filter-out-animation": filterOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
     },
     {
@@ -302,7 +313,7 @@ export function addBaseAnimations(
           modifier || "mirror"
         ),
         animationComposition: "accumulate",
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
     },
     {
@@ -320,13 +331,13 @@ export function addBaseAnimations(
       "motion-grayscale-in": (value) => ({
         "--motion-origin-grayscale": value,
         "--motion-filter-in-animation": filterInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
 
       "motion-grayscale-out": (value) => ({
         "--motion-end-grayscale": value,
         "--motion-filter-out-animation": filterOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
     },
     {
@@ -361,13 +372,13 @@ export function addBaseAnimations(
       "motion-opacity-in": (value) => ({
         "--motion-origin-opacity": value,
         "--motion-opacity-in-animation": opacityInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
 
       "motion-opacity-out": (value) => ({
         "--motion-end-opacity": value,
         "--motion-opacity-out-animation": opacityOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
     },
     {
@@ -385,7 +396,7 @@ export function addBaseAnimations(
           modifier || "mirror"
         ),
         animationComposition: "accumulate",
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
     },
     {
@@ -403,13 +414,13 @@ export function addBaseAnimations(
       "motion-bg-in": (value) => ({
         "--motion-origin-background-color": value,
         "--motion-background-color-in-animation": backgroundColorInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
 
       "motion-bg-out": (value) => ({
         "--motion-end-background-color": value,
         "--motion-background-color-out-animation": backgroundColorOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
     },
     {
@@ -426,7 +437,7 @@ export function addBaseAnimations(
         "--motion-background-color-loop-animation":
           backgroundColorLoopAnimation(modifier || "mirror"),
         // no animation composition because it makes colors add
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
     },
     {
@@ -445,13 +456,13 @@ export function addBaseAnimations(
       "motion-text-in": (value) => ({
         "--motion-origin-text-color": value,
         "--motion-text-color-in-animation": textColorInAnimation,
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
 
       "motion-text-out": (value) => ({
         "--motion-end-text-color": value,
         "--motion-text-color-out-animation": textColorOutAnimation,
-        animation: "var(--motion-all-exit-animations)",
+        animation: allExitAnimations,
       }),
     },
     {
@@ -469,7 +480,7 @@ export function addBaseAnimations(
           modifier || "mirror"
         ),
         animationComposition: "accumulate",
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
     },
     {

--- a/src/baseAnimations.ts
+++ b/src/baseAnimations.ts
@@ -18,16 +18,16 @@ type ThemeConfig = {
   scale: Record<string, string>;
 };
 
-const allEnterAnimations =
+export const allEnterAnimations =
   "var(--motion-scale-in-animation), var(--motion-translate-in-animation), var(--motion-rotate-in-animation), var(--motion-filter-in-animation), var(--motion-opacity-in-animation), var(--motion-background-color-in-animation), var(--motion-text-color-in-animation)";
 
-const allExitAnimations =
+export const allExitAnimations =
   "var(--motion-scale-out-animation), var(--motion-translate-out-animation), var(--motion-rotate-out-animation), var(--motion-filter-out-animation), var(--motion-opacity-out-animation), var(--motion-background-color-out-animation), var(--motion-text-color-out-animation)";
 
-const allLoopAnimations =
+export const allLoopAnimations =
   "var(--motion-scale-loop-animation), var(--motion-translate-loop-animation), var(--motion-rotate-loop-animation), var(--motion-filter-loop-animation), var(--motion-opacity-loop-animation), var(--motion-background-color-loop-animation), var(--motion-text-color-loop-animation)";
 
-const allLoopAndEnterAnimations = `${allEnterAnimations}, ${allLoopAnimations}`;
+export const allLoopAndEnterAnimations = `${allEnterAnimations}, ${allLoopAnimations}`;
 
 // animation strings
 export const scaleInAnimation =
@@ -354,7 +354,7 @@ export function addBaseAnimations(
           modifier || "mirror"
         ),
         animationComposition: "accumulate",
-        animation: "var(--motion-all-loop-and-enter-animations)",
+        animation: allLoopAndEnterAnimations,
       }),
     },
     {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,169 +1,399 @@
 import type { PluginAPI } from "tailwindcss/types/config.js";
 
 export default function addDefaults(addBase: PluginAPI["addBase"]) {
-  // default values for the motion variables
+  /**
+   * Default values for the motion variables
+   */
   addBase({
-    ":root": {
-      "--motion-default-timing": "cubic-bezier(.165, .84, .44, 1)",
-
-      "--motion-bounce":
+    /**
+     * Easing functions
+     */
+    "@property --motion-bounce": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value":
         "linear(0, 0.004, 0.016, 0.035, 0.063, 0.098, 0.141 13.6%, 0.25, 0.391, 0.563, 0.765,1, 0.891 40.9%, 0.848, 0.813, 0.785, 0.766, 0.754, 0.75, 0.754, 0.766, 0.785,0.813, 0.848, 0.891 68.2%, 1 72.7%, 0.973, 0.953, 0.941, 0.938, 0.941, 0.953,0.973, 1, 0.988, 0.984, 0.988, 1)",
+    },
 
-      // from https://www.kvin.me/css-springs
-      // Bounce: 0%
-      "--motion-spring-smooth":
+    // from https://www.kvin.me/css-springs
+    "@property --motion-spring-smooth": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value":
         "linear(0, 0.001 0.44%, 0.0045 0.94%, 0.0195 2.03%, 0.0446 3.19%, 0.0811 4.5%, 0.1598 6.82%, 0.3685 12.34%, 0.4693 15.17%, 0.5663, 0.6498 21.27%, 0.7215 24.39%, 0.7532 25.98%, 0.7829 27.65%, 0.8105, 0.8349 31.14%, 0.8573 32.95%, 0.8776 34.84%, 0.8964 36.87%, 0.9136 39.05%, 0.929 41.37%, 0.9421 43.77%, 0.9537 46.38%, 0.9636 49.14%, 0.9789 55.31%, 0.9888 62.35%, 0.9949 71.06%, 0.9982 82.52%, 0.9997 99.94%)",
+    },
 
-      // Bounce: 15%
-      "--motion-spring-snappy":
+    "@property --motion-spring-snappy": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value":
         "linear(0, 0.0014, 0.0053 1.02%, 0.0126, 0.0227 2.18%, 0.0517 3.41%, 0.094 4.79%, 0.1865 7.26%, 0.4182 12.77%, 0.5246 15.46%, 0.6249, 0.7112, 0.7831 23.95%, 0.8146 25.4%, 0.844, 0.8699 28.45%, 0.8935, 0.9139 31.64%, 0.932, 0.9473, 0.9601 36.65%, 0.9714 38.47%, 0.9808 40.35%, 0.9948 44.49%, 1.0031 49.43%, 1.0057 53.35%, 1.0063 58.14%, 1.0014 80.78%, 1.0001 99.94%)",
+    },
 
-      // Bounce: 30%
-      "--motion-spring-bouncy":
+    "@property --motion-spring-bouncy": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value":
         "linear(0, 0.0018, 0.0069, 0.0151 1.74%, 0.0277 2.4%, 0.062 3.7%, 0.1115 5.15%, 0.2211 7.77%, 0.4778 13.21%, 0.5912 15.75%, 0.6987 18.44%, 0.7862 20.98%, 0.861 23.59%, 0.8926, 0.9205, 0.945 27.51%, 0.9671 28.89%, 0.9868, 1.003 31.79%, 1.0224 34.11%, 1.0358 36.58%, 1.0436 39.27%, 1.046 42.31%, 1.0446 44.71%, 1.0406 47.47%, 1.0118 61.84%, 1.0027 69.53%, 0.9981 80.49%, 0.9991 99.94%)",
+    },
 
-      // Bounce: 50%
-      "--motion-spring-bouncier":
+    "@property --motion-spring-bouncier": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value":
         "linear(0, 0.0023, 0.0088, 0.0194 1.59%, 0.035 2.17%, 0.078 3.33%, 0.1415 4.64%, 0.2054 5.75%, 0.2821 6.95%, 0.5912 11.45%, 0.7205 13.43%, 0.8393 15.45%, 0.936 17.39%, 0.9778, 1.015, 1.0477, 1.0759, 1.0998 22.22%, 1.1203, 1.1364, 1.1484 25.26%, 1.1586 26.61%, 1.1629 28.06%, 1.1613 29.56%, 1.1537 31.2%, 1.1434 32.6%, 1.1288 34.19%, 1.0508 41.29%, 1.0174 44.87%, 1.0025 46.89%, 0.9911 48.87%, 0.9826 50.9%, 0.9769 53.03%, 0.9735 56.02%, 0.9748 59.45%, 0.9964 72.64%, 1.0031 79.69%, 1.0042 86.83%, 1.0008 99.97%)",
+    },
 
-      // Bounce: 80%
-      "--motion-spring-bounciest":
+    "@property --motion-spring-bounciest": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value":
         "linear(0, 0.0032, 0.0131, 0.0294, 0.0524, 0.0824, 0.1192 1.54%, 0.2134 2.11%, 0.3102 2.59%, 0.4297 3.13%, 0.8732 4.95%, 1.0373, 1.1827 6.36%, 1.2972 7.01%, 1.3444, 1.3859, 1.4215, 1.4504, 1.4735, 1.4908, 1.5024, 1.5084 9.5%, 1.5091, 1.5061, 1.4993, 1.4886, 1.4745, 1.4565 11.11%, 1.4082 11.7%, 1.3585 12.2%, 1.295 12.77%, 1.0623 14.64%, 0.9773, 0.9031 16.08%, 0.8449 16.73%, 0.8014, 0.7701 17.95%, 0.7587, 0.7501, 0.7443, 0.7412 19.16%, 0.7421 19.68%, 0.7508 20.21%, 0.7672 20.77%, 0.7917 21.37%, 0.8169 21.87%, 0.8492 22.43%, 0.9681 24.32%, 1.0114, 1.0492 25.75%, 1.0789 26.41%, 1.1008, 1.1167, 1.1271, 1.1317 28.81%, 1.1314, 1.1271 29.87%, 1.1189 30.43%, 1.1063 31.03%, 1.0769 32.11%, 0.9941 34.72%, 0.9748 35.43%, 0.9597 36.09%, 0.9487, 0.9407, 0.9355, 0.933 38.46%, 0.9344 39.38%, 0.9421 40.38%, 0.9566 41.5%, 0.9989 44.12%, 1.0161 45.37%, 1.029 46.75%, 1.0341 48.1%, 1.0335 49.04%, 1.0295 50.05%, 1.0221 51.18%, 0.992 55.02%, 0.9854 56.38%, 0.9827 57.72%, 0.985 59.73%, 1.004 64.67%, 1.0088 67.34%, 1.0076 69.42%, 0.9981 74.28%, 0.9956 76.85%, 0.9961 79.06%, 1.0023 86.46%, 0.999 95.22%, 0.9994 100%)",
     },
 
-    // i didn't find a documented way to set these default variables
-    // an issue and a discussion about this:
-    // https://github.com/tailwindlabs/tailwindcss/issues/10514#issuecomment-1420879057
-    // https://github.com/tailwindlabs/tailwindcss/discussions/8747
-    "*": {
-      // enter animations origin values
-      "--motion-origin-scale-x": "100%",
-      "--motion-origin-scale-y": "100%",
-      "--motion-origin-translate-x": "0%",
-      "--motion-origin-translate-y": "0%",
-      "--motion-origin-rotate": "0deg",
-      "--motion-origin-blur": "0px",
-      "--motion-origin-grayscale": "0%",
-      "--motion-origin-opacity": "100%",
-      "--motion-origin-background-color": "",
-      "--motion-origin-text-color": "",
+    /**
+     * Enter animations origin values
+     */
+    "@property --motion-origin-scale-x": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
 
-      // exit animations end values
-      "--motion-end-scale-x": "100%",
-      "--motion-end-scale-y": "100%",
-      "--motion-end-translate-x": "0%",
-      "--motion-end-translate-y": "0%",
-      "--motion-end-rotate": "0deg",
-      "--motion-end-blur": "0px",
-      "--motion-end-grayscale": "0%",
-      "--motion-end-opacity": "100%",
-      "--motion-end-background-color": "",
-      "--motion-end-text-color": "",
+    "@property --motion-origin-scale-y": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
 
-      // loop animations values
-      "--motion-loop-scale-x": "100%",
-      "--motion-loop-scale-y": "100%",
-      "--motion-loop-translate-x": "0%",
-      "--motion-loop-translate-y": "0%",
-      "--motion-loop-rotate": "0deg",
-      "--motion-loop-blur": "0px",
-      "--motion-loop-grayscale": "0%",
-      "--motion-loop-opacity": "100%",
-      "--motion-loop-background-color": "",
-      "--motion-loop-text-color": "",
+    "@property --motion-origin-translate-x": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
 
-      // animation modifiers
-      "--motion-duration": "700ms",
-      "--motion-timing": "var(--motion-default-timing)",
-      "--motion-perceptual-duration-multiplier": "1",
-      "--motion-delay": "0ms",
-      "--motion-loop-count": "infinite",
+    "@property --motion-origin-translate-y": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
 
-      //animation modifiers for each animation
-      "--motion-scale-duration": "var(--motion-duration)",
-      "--motion-scale-timing": "var(--motion-timing)",
-      "--motion-scale-perceptual-duration-multiplier":
-        "var(--motion-perceptual-duration-multiplier)",
-      "--motion-scale-delay": "var(--motion-delay)",
-      "--motion-scale-loop-count": "var(--motion-loop-count)",
+    "@property --motion-origin-rotate": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0deg",
+    },
 
-      "--motion-translate-duration": "var(--motion-duration)",
-      "--motion-translate-timing": "var(--motion-timing)",
-      "--motion-translate-perceptual-duration-multiplier":
-        "var(--motion-perceptual-duration-multiplier)",
-      "--motion-translate-delay": "var(--motion-delay)",
-      "--motion-translate-loop-count": "var(--motion-loop-count)",
+    "@property --motion-origin-blur": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0px",
+    },
 
-      "--motion-rotate-duration": "var(--motion-duration)",
-      "--motion-rotate-timing": "var(--motion-timing)",
-      "--motion-rotate-perceptual-duration-multiplier":
-        "var(--motion-perceptual-duration-multiplier)",
-      "--motion-rotate-delay": "var(--motion-delay)",
-      "--motion-rotate-loop-count": "var(--motion-loop-count)",
+    "@property --motion-origin-grayscale": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
 
-      // filter groups blur and grayscale
-      "--motion-filter-duration": "var(--motion-duration)",
-      "--motion-filter-timing": "var(--motion-timing)",
-      "--motion-filter-perceptual-duration-multiplier":
-        "var(--motion-perceptual-duration-multiplier)",
-      "--motion-filter-delay": "var(--motion-delay)",
-      "--motion-filter-loop-count": "var(--motion-loop-count)",
+    "@property --motion-origin-opacity": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
 
-      "--motion-opacity-duration": "var(--motion-duration)",
-      "--motion-opacity-timing": "var(--motion-timing)",
-      "--motion-opacity-perceptual-duration-multiplier":
-        "var(--motion-perceptual-duration-multiplier)",
-      "--motion-opacity-delay": "var(--motion-delay)",
-      "--motion-opacity-loop-count": "var(--motion-loop-count)",
+    "@property --motion-origin-background-color": {
+      syntax: '"*"',
+      inherits: "false",
+    },
 
-      "--motion-background-color-duration": "var(--motion-duration)",
-      "--motion-background-color-timing": "var(--motion-timing)",
-      "--motion-background-color-perceptual-duration-multiplier":
-        "var(--motion-perceptual-duration-multiplier)",
-      "--motion-background-color-delay": "var(--motion-delay)",
-      "--motion-background-color-loop-count": "var(--motion-loop-count)",
+    "@property --motion-origin-text-color": {
+      syntax: '"*"',
+      inherits: "false",
+    },
 
-      "--motion-text-color-duration": "var(--motion-duration)",
-      "--motion-text-color-timing": "var(--motion-timing)",
-      "--motion-text-color-perceptual-duration-multiplier":
-        "var(--motion-perceptual-duration-multiplier)",
-      "--motion-text-color-delay": "var(--motion-delay)",
-      "--motion-text-color-loop-count": "var(--motion-loop-count)",
+    /**
+     * Exit animations end values
+     */
+    "@property --motion-end-scale-x": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
 
-      // default animations to none
-      "--motion-scale-in-animation": "none",
-      "--motion-translate-in-animation": "none",
-      "--motion-rotate-in-animation": "none",
-      "--motion-filter-in-animation": "none",
-      "--motion-opacity-in-animation": "none",
-      "--motion-background-color-in-animation": "none",
-      "--motion-text-color-in-animation": "none",
+    "@property --motion-end-scale-y": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
 
-      "--motion-scale-out-animation": "none",
-      "--motion-translate-out-animation": "none",
-      "--motion-rotate-out-animation": "none",
-      "--motion-filter-out-animation": "none",
-      "--motion-opacity-out-animation": "none",
-      "--motion-background-color-out-animation": "none",
-      "--motion-text-color-out-animation": "none",
+    "@property --motion-end-translate-x": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
 
-      "--motion-scale-loop-animation": "none",
-      "--motion-translate-loop-animation": "none",
-      "--motion-rotate-loop-animation": "none",
-      "--motion-filter-loop-animation": "none",
-      "--motion-opacity-loop-animation": "none",
-      "--motion-background-color-loop-animation": "none",
-      "--motion-text-color-loop-animation": "none",
+    "@property --motion-end-translate-y": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
 
-      // all animations
-      "--motion-all-enter-animations":
-        "var(--motion-scale-in-animation), var(--motion-translate-in-animation), var(--motion-rotate-in-animation), var(--motion-filter-in-animation), var(--motion-opacity-in-animation), var(--motion-background-color-in-animation), var(--motion-text-color-in-animation)",
-      "--motion-all-exit-animations":
-        "var(--motion-scale-out-animation), var(--motion-translate-out-animation), var(--motion-rotate-out-animation), var(--motion-filter-out-animation), var(--motion-opacity-out-animation), var(--motion-background-color-out-animation), var(--motion-text-color-out-animation)",
-      "--motion-all-loop-animations":
-        "var(--motion-scale-loop-animation), var(--motion-translate-loop-animation), var(--motion-rotate-loop-animation), var(--motion-filter-loop-animation), var(--motion-opacity-loop-animation), var(--motion-background-color-loop-animation), var(--motion-text-color-loop-animation)",
-      "--motion-all-loop-and-enter-animations":
-        "var(--motion-all-loop-animations), var(--motion-all-enter-animations)",
+    "@property --motion-end-rotate": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0deg",
+    },
+
+    "@property --motion-end-blur": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0px",
+    },
+
+    "@property --motion-end-grayscale": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
+
+    "@property --motion-end-opacity": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
+
+    "@property --motion-end-background-color": {
+      syntax: '"*"',
+      inherits: "false",
+    },
+
+    "@property --motion-end-text-color": {
+      syntax: '"*"',
+      inherits: "false",
+    },
+
+    /**
+     * Loop animations values
+     */
+    "@property --motion-loop-scale-x": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
+
+    "@property --motion-loop-scale-y": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
+
+    "@property --motion-loop-translate-x": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
+
+    "@property --motion-loop-translate-y": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
+
+    "@property --motion-loop-rotate": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0deg",
+    },
+
+    "@property --motion-loop-blur": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0px",
+    },
+
+    "@property --motion-loop-grayscale": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0%",
+    },
+
+    "@property --motion-loop-opacity": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "100%",
+    },
+
+    "@property --motion-loop-background-color": {
+      syntax: '"*"',
+      inherits: "false",
+    },
+
+    "@property --motion-loop-text-color": {
+      syntax: '"*"',
+      inherits: "false",
+    },
+
+    /**
+     * Animation modifiers
+     */
+    "@property --motion-duration": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "700ms",
+    },
+
+    "@property --motion-timing": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "cubic-bezier(.165, .84, .44, 1)",
+    },
+
+    "@property --motion-perceptual-duration-multiplier": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "1",
+    },
+
+    "@property --motion-delay": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "0ms",
+    },
+
+    "@property --motion-loop-count": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "infinite",
+    },
+
+    /**
+     * Default animations to none
+     */
+    "@property --motion-scale-in-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-translate-in-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-rotate-in-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-filter-in-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-opacity-in-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-background-color-in-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-text-color-in-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-scale-out-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-translate-out-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-rotate-out-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-filter-out-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-opacity-out-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-background-color-out-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-text-color-out-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-scale-loop-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-translate-loop-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-rotate-loop-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-filter-loop-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-opacity-loop-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-background-color-loop-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
+    },
+
+    "@property --motion-text-color-loop-animation": {
+      syntax: '"*"',
+      inherits: "false",
+      "initial-value": "none",
     },
   });
 }

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -9,6 +9,7 @@ import {
   scaleLoopAnimation,
   translateInAnimation,
   translateLoopAnimation,
+  allLoopAndEnterAnimations,
 } from "./baseAnimations.js";
 import { springPerceptualMultipliers } from "./modifiers.js";
 
@@ -39,7 +40,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-duration": durations[size as Size],
           "--motion-opacity-in-animation": opacityInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-slide-right": (size: string) => {
@@ -53,7 +54,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-slide-left": (size: string) => {
@@ -67,7 +68,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-slide-up": (size: string) => {
@@ -81,7 +82,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-slide-down": (size: string) => {
@@ -95,7 +96,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-slide-up-right": (size: string) => {
@@ -110,7 +111,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-slide-up-left": (size: string) => {
@@ -125,7 +126,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-slide-down-left": (size: string) => {
@@ -140,7 +141,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-slide-down-right": (size: string) => {
@@ -155,7 +156,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
 
@@ -170,7 +171,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
 
@@ -192,7 +193,7 @@ export function addPresets(
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-blur-left": (size: string) => {
@@ -213,7 +214,7 @@ export function addPresets(
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-blur-up": (size: string) => {
@@ -234,7 +235,7 @@ export function addPresets(
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-blur-down": (size: string) => {
@@ -255,7 +256,7 @@ export function addPresets(
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-filter-in-animation": filterInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
     },
@@ -295,7 +296,7 @@ export function addPresets(
           "--motion-origin-opacity": "0",
           "--motion-opacity-in-animation": opacityInAnimation,
           "--motion-translate-in-animation": translateInAnimation,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
     },
@@ -321,7 +322,7 @@ export function addPresets(
       "--motion-origin-translate-y": "-25%",
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-translate-in-animation": translateInAnimation,
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 
@@ -332,7 +333,7 @@ export function addPresets(
       "--motion-origin-opacity": "0",
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-scale-in-animation": scaleInAnimation,
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 
@@ -343,7 +344,7 @@ export function addPresets(
       "--motion-origin-opacity": "0",
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-scale-in-animation": scaleInAnimation,
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 
@@ -358,7 +359,7 @@ export function addPresets(
         DEFAULT_MULTIPLIER,
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-scale-in-animation": scaleInAnimation,
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 
@@ -373,7 +374,7 @@ export function addPresets(
         DEFAULT_MULTIPLIER,
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-scale-in-animation": scaleInAnimation,
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 
@@ -388,7 +389,7 @@ export function addPresets(
         DEFAULT_MULTIPLIER,
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-rotate-in-animation": rotateInAnimation,
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 
@@ -408,7 +409,7 @@ export function addPresets(
       "--motion-opacity-in-animation": opacityInAnimation,
       "--motion-rotate-in-animation": rotateInAnimation,
       "--motion-translate-in-animation": translateInAnimation,
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 
@@ -540,7 +541,7 @@ export function addPresets(
           "--motion-loop-scale-y": sizes[size as Size],
           "--motion-timing": "cubic-bezier(0.4, 0, 0.2, 1)",
           "--motion-scale-loop-animation": scaleLoopAnimation("mirror"),
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-wobble": (size: string) => {
@@ -553,7 +554,7 @@ export function addPresets(
           "--motion-loop-translate-x": sizes[size as Size],
           "--motion-timing": "cubic-bezier(0.4, 0, 0.2, 1)",
           "--motion-translate-loop-animation": translateLoopAnimation("mirror"),
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-seesaw": (size: string) => {
@@ -569,7 +570,7 @@ export function addPresets(
           "--motion-rotate-perceptual-duration-multiplier":
             springPerceptualMultipliers["var(--motion-spring-bounciest)"] ??
             DEFAULT_MULTIPLIER,
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-oscillate": (size: string) => {
@@ -582,7 +583,7 @@ export function addPresets(
           "--motion-loop-translate-y": sizes[size as Size],
           "--motion-timing": "cubic-bezier(0.4, 0, 0.2, 1)",
           "--motion-translate-loop-animation": translateLoopAnimation("mirror"),
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-stretch": (size: string) => {
@@ -604,7 +605,7 @@ export function addPresets(
             springPerceptualMultipliers["var(--motion-spring-bouncier)"] ??
             DEFAULT_MULTIPLIER,
           "--motion-scale-loop-animation": scaleLoopAnimation("mirror"),
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
       "motion-preset-float": (size: string) => {
@@ -621,7 +622,7 @@ export function addPresets(
             DEFAULT_MULTIPLIER,
           "--motion-duration": "2000ms",
           "--motion-translate-loop-animation": translateLoopAnimation("mirror"),
-          animation: "var(--motion-all-loop-and-enter-animations)",
+          animation: allLoopAndEnterAnimations,
         };
       },
     },
@@ -640,7 +641,7 @@ export function addPresets(
       "--motion-loop-rotate": "360deg",
       "--motion-timing": "linear",
       "--motion-rotate-loop-animation": rotateLoopAnimation("reset"),
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 
@@ -648,7 +649,7 @@ export function addPresets(
     ".motion-preset-blink": {
       "--motion-loop-opacity": "0",
       "--motion-opacity-loop-animation": opacityLoopAnimation("mirror"),
-      animation: "var(--motion-all-loop-and-enter-animations)",
+      animation: allLoopAndEnterAnimations,
     },
   });
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -7,7 +7,7 @@
     class="bg-black flex justify-center items-center text-white text-9xl h-screen"
   >
     <h1
-      class="h-[var(--test-property)] motion-opacity-loop-[--ey] motion-scale-loop-[--motion-loop-scale]"
+      class="motion-opacity-loop-[--ey] motion-scale-loop-[--motion-loop-scale]"
       style={{ "--ey": "0", "--motion-loop-scale": "0.9" }}
     >
       Rombo

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -7,7 +7,7 @@
     class="bg-black flex justify-center items-center text-white text-9xl h-screen"
   >
     <h1
-      class="motion-opacity-loop-[--ey] motion-scale-loop-[--motion-loop-scale]"
+      class="h-[var(--test-property)] motion-opacity-loop-[--ey] motion-scale-loop-[--motion-loop-scale]"
       style={{ "--ey": "0", "--motion-loop-scale": "0.9" }}
     >
       Rombo


### PR DESCRIPTION
Great library 🎉

But one drawback I noticed was the huge log in devtools for every single element in the tree. I looked in the code, where a comment said you didn't find a better aproach. So I tried.

![image](https://github.com/user-attachments/assets/6c772a5d-a0d7-47c1-b42a-9e24b0ad600e)

### What changed
Mainly I tried to use [@property](https://developer.mozilla.org/en-US/docs/Web/CSS/@property) for defaults, as it doesn't cluther the devtools so much. However some of the properties have variables as a initial values, later used in `src/baseAnimations.ts` directly. I added those as a fallback value in case only the default is filled in. For the final `--motion-all-*-animations` I moved them only to elements that have defined some animation.

### Implications for users
**None**. Better debugging experience. No clutter in DevTools.

### Implications for maintainers
The composition of the code changed a bit so it may be harder to understand, but I think that when you read through the code for a while it's okay.

_PS: I have not seen anyone else find an issue with this, if I'm missing something. Let me know please._
