### PR TITLE
feat: add motion-direction utilities for animation-direction

### DIFF
--- a/src/modifiers.ts
+++ b/src/modifiers.ts
@@ -234,6 +234,46 @@ export function addModifiers(
     },
   });
 
+  // animation direction
+  addUtilities({
+    ".motion-direction-normal": {
+      animationDirection: "normal",
+      "&::before": {
+        animationDirection: "normal",
+      },
+      "&::after": {
+        animationDirection: "normal",
+      },
+    },
+    ".motion-direction-reverse": {
+      animationDirection: "reverse",
+      "&::before": {
+        animationDirection: "reverse",
+      },
+      "&::after": {
+        animationDirection: "reverse",
+      },
+    },
+    ".motion-direction-alternate": {
+      animationDirection: "alternate",
+      "&::before": {
+        animationDirection: "alternate",
+      },
+      "&::after": {
+        animationDirection: "alternate",
+      },
+    },
+    ".motion-direction-alternate-reverse": {
+      animationDirection: "alternate-reverse",
+      "&::before": {
+        animationDirection: "alternate-reverse",
+      },
+      "&::after": {
+        animationDirection: "alternate-reverse",
+      },
+    },
+  });
+
   // loop
   matchUtilities(
     {


### PR DESCRIPTION
Adds `motion-direction-{keyword}` utilities for controlling CSS `animation-direction` property.

## Added utilities
- `motion-direction-normal` - plays animation forward
- `motion-direction-reverse` - plays animation backward
- `motion-direction-alternate` - alternates forward/backward each cycle
- `motion-direction-alternate-reverse` - starts backward, then alternates

Utilities apply to element and `::before`/`::after` pseudo-elements, consistent with existing motion utilities.

